### PR TITLE
Replaced constructor based injection with setter based injection

### DIFF
--- a/src/main/java/io/xlate/jsonapi/rvp/internal/validation/boundary/TransactionalValidator.java
+++ b/src/main/java/io/xlate/jsonapi/rvp/internal/validation/boundary/TransactionalValidator.java
@@ -16,11 +16,10 @@ import io.xlate.jsonapi.rvp.internal.JsonApiErrorException;
 @ApplicationScoped
 public class TransactionalValidator {
 
-    private final Validator validator;
+    private Validator validator;
 
     @Inject
-    public TransactionalValidator(Validator validator) {
-        super();
+    public void setValidator(Validator validator) {
         this.validator = validator;
     }
 

--- a/src/test/java/io/xlate/jsonapi/rvp/JsonApiResourceTest.java
+++ b/src/test/java/io/xlate/jsonapi/rvp/JsonApiResourceTest.java
@@ -80,7 +80,8 @@ class JsonApiResourceTest {
         target.handlers = Mockito.mock(Instance.class);
         target.request = Mockito.mock(Request.class);
         target.security = Mockito.mock(SecurityContext.class);
-        target.txValidator = new TransactionalValidator(target.validator);
+        target.txValidator = new TransactionalValidator();
+        target.txValidator.setValidator(target.validator);
 
         Mockito.when(target.handlers.iterator()).thenReturn(handlerIterator());
 


### PR DESCRIPTION
The CDI spec requires a normal scoped bean to be proxyable which requires the bean to provide a no-arg constructor [1].

[1]: https://jakarta.ee/specifications/cdi/4.0/jakarta-cdi-spec-4.0#unproxyable