### PR TITLE
Removed AGPL license headers

### DIFF
--- a/src/main/java/io/xlate/jsonapi/rvp/JsonApiMediaType.java
+++ b/src/main/java/io/xlate/jsonapi/rvp/JsonApiMediaType.java
@@ -1,19 +1,3 @@
-/*******************************************************************************
- * Copyright (C) 2018 xlate.io LLC, http://www.xlate.io
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
 package io.xlate.jsonapi.rvp;
 
 import jakarta.ws.rs.core.MediaType;

--- a/src/main/java/io/xlate/jsonapi/rvp/JsonApiResource.java
+++ b/src/main/java/io/xlate/jsonapi/rvp/JsonApiResource.java
@@ -1,19 +1,3 @@
-/*******************************************************************************
- * Copyright (C) 2018 xlate.io LLC, http://www.xlate.io
- *
- * This program is free software: you can redistribute it and/or modify it under
- * the terms of the GNU Affero General Public License as published by the Free
- * Software Foundation, either version 3 of the License, or (at your option) any
- * later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
- * details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
 package io.xlate.jsonapi.rvp;
 
 import java.io.IOException;

--- a/src/main/java/io/xlate/jsonapi/rvp/JsonApiStatus.java
+++ b/src/main/java/io/xlate/jsonapi/rvp/JsonApiStatus.java
@@ -1,19 +1,3 @@
-/*******************************************************************************
- * Copyright (C) 2018 xlate.io LLC, http://www.xlate.io
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
 package io.xlate.jsonapi.rvp;
 
 import jakarta.ws.rs.core.Response.Status.Family;

--- a/src/main/java/io/xlate/jsonapi/rvp/internal/JsonApiErrorException.java
+++ b/src/main/java/io/xlate/jsonapi/rvp/internal/JsonApiErrorException.java
@@ -1,19 +1,3 @@
-/*******************************************************************************
- * Copyright (C) 2018 xlate.io LLC, http://www.xlate.io
- *
- * This program is free software: you can redistribute it and/or modify it under
- * the terms of the GNU Affero General Public License as published by the Free
- * Software Foundation, either version 3 of the License, or (at your option) any
- * later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
- * details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
 package io.xlate.jsonapi.rvp.internal;
 
 import java.io.IOException;

--- a/src/main/java/io/xlate/jsonapi/rvp/internal/persistence/boundary/PersistenceController.java
+++ b/src/main/java/io/xlate/jsonapi/rvp/internal/persistence/boundary/PersistenceController.java
@@ -1,19 +1,3 @@
-/*******************************************************************************
- * Copyright (C) 2018 xlate.io LLC, http://www.xlate.io
- *
- * This program is free software: you can redistribute it and/or modify it under
- * the terms of the GNU Affero General Public License as published by the Free
- * Software Foundation, either version 3 of the License, or (at your option) any
- * later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
- * details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
 package io.xlate.jsonapi.rvp.internal.persistence.boundary;
 
 import static java.util.function.Predicate.not;

--- a/src/main/java/io/xlate/jsonapi/rvp/internal/persistence/entity/EntityMeta.java
+++ b/src/main/java/io/xlate/jsonapi/rvp/internal/persistence/entity/EntityMeta.java
@@ -1,19 +1,3 @@
-/*******************************************************************************
- * Copyright (C) 2018 xlate.io LLC, http://www.xlate.io
- *
- * This program is free software: you can redistribute it and/or modify it under
- * the terms of the GNU Affero General Public License as published by the Free
- * Software Foundation, either version 3 of the License, or (at your option) any
- * later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
- * details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
 package io.xlate.jsonapi.rvp.internal.persistence.entity;
 
 import java.beans.BeanInfo;

--- a/src/main/java/io/xlate/jsonapi/rvp/internal/persistence/entity/EntityMetamodel.java
+++ b/src/main/java/io/xlate/jsonapi/rvp/internal/persistence/entity/EntityMetamodel.java
@@ -1,19 +1,3 @@
-/*******************************************************************************
- * Copyright (C) 2018 xlate.io LLC, http://www.xlate.io
- *
- * This program is free software: you can redistribute it and/or modify it under
- * the terms of the GNU Affero General Public License as published by the Free
- * Software Foundation, either version 3 of the License, or (at your option) any
- * later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
- * details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
 package io.xlate.jsonapi.rvp.internal.persistence.entity;
 
 import java.util.HashMap;

--- a/src/main/java/io/xlate/jsonapi/rvp/internal/rs/boundary/ResourceObjectReader.java
+++ b/src/main/java/io/xlate/jsonapi/rvp/internal/rs/boundary/ResourceObjectReader.java
@@ -1,19 +1,3 @@
-/*******************************************************************************
- * Copyright (C) 2018 xlate.io LLC, http://www.xlate.io
- *
- * This program is free software: you can redistribute it and/or modify it under
- * the terms of the GNU Affero General Public License as published by the Free
- * Software Foundation, either version 3 of the License, or (at your option) any
- * later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
- * details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
 package io.xlate.jsonapi.rvp.internal.rs.boundary;
 
 import static io.xlate.jsonapi.rvp.internal.rs.entity.JsonApiError.relationshipPointer;

--- a/src/main/java/io/xlate/jsonapi/rvp/internal/rs/boundary/ResourceObjectWriter.java
+++ b/src/main/java/io/xlate/jsonapi/rvp/internal/rs/boundary/ResourceObjectWriter.java
@@ -1,19 +1,3 @@
-/*******************************************************************************
- * Copyright (C) 2018 xlate.io LLC, http://www.xlate.io
- *
- * This program is free software: you can redistribute it and/or modify it under
- * the terms of the GNU Affero General Public License as published by the Free
- * Software Foundation, either version 3 of the License, or (at your option) any
- * later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
- * details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
 package io.xlate.jsonapi.rvp.internal.rs.boundary;
 
 import java.math.BigDecimal;

--- a/src/main/java/io/xlate/jsonapi/rvp/internal/rs/entity/InternalQuery.java
+++ b/src/main/java/io/xlate/jsonapi/rvp/internal/rs/entity/InternalQuery.java
@@ -1,19 +1,3 @@
-/*******************************************************************************
- * Copyright (C) 2018 xlate.io LLC, http://www.xlate.io
- *
- * This program is free software: you can redistribute it and/or modify it under
- * the terms of the GNU Affero General Public License as published by the Free
- * Software Foundation, either version 3 of the License, or (at your option) any
- * later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
- * details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
 package io.xlate.jsonapi.rvp.internal.rs.entity;
 
 import static io.xlate.jsonapi.rvp.internal.validation.boundary.JsonApiUriQueryValidator.getRelatedEntityMeta;

--- a/src/main/java/io/xlate/jsonapi/rvp/internal/rs/entity/JsonApiRequest.java
+++ b/src/main/java/io/xlate/jsonapi/rvp/internal/rs/entity/JsonApiRequest.java
@@ -1,19 +1,3 @@
-/*******************************************************************************
- * Copyright (C) 2018 xlate.io LLC, http://www.xlate.io
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
 package io.xlate.jsonapi.rvp.internal.rs.entity;
 
 import jakarta.json.JsonObject;

--- a/src/main/java/io/xlate/jsonapi/rvp/internal/validation/boundary/JsonApiRequestValidator.java
+++ b/src/main/java/io/xlate/jsonapi/rvp/internal/validation/boundary/JsonApiRequestValidator.java
@@ -1,19 +1,3 @@
-/*******************************************************************************
- * Copyright (C) 2018 xlate.io LLC, http://www.xlate.io
- *
- * This program is free software: you can redistribute it and/or modify it under
- * the terms of the GNU Affero General Public License as published by the Free
- * Software Foundation, either version 3 of the License, or (at your option) any
- * later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
- * details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
 package io.xlate.jsonapi.rvp.internal.validation.boundary;
 
 import static java.util.function.Predicate.not;

--- a/src/main/java/io/xlate/jsonapi/rvp/internal/validation/boundary/JsonApiUriQueryValidator.java
+++ b/src/main/java/io/xlate/jsonapi/rvp/internal/validation/boundary/JsonApiUriQueryValidator.java
@@ -1,19 +1,3 @@
-/*******************************************************************************
- * Copyright (C) 2018 xlate.io LLC, http://www.xlate.io
- *
- * This program is free software: you can redistribute it and/or modify it under
- * the terms of the GNU Affero General Public License as published by the Free
- * Software Foundation, either version 3 of the License, or (at your option) any
- * later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
- * details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
 package io.xlate.jsonapi.rvp.internal.validation.boundary;
 
 import java.util.HashSet;

--- a/src/main/java/io/xlate/jsonapi/rvp/internal/validation/boundary/ValidJsonApiQuery.java
+++ b/src/main/java/io/xlate/jsonapi/rvp/internal/validation/boundary/ValidJsonApiQuery.java
@@ -1,19 +1,3 @@
-/*******************************************************************************
- * Copyright (C) 2018 xlate.io LLC, http://www.xlate.io
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
 package io.xlate.jsonapi.rvp.internal.validation.boundary;
 
 import static java.lang.annotation.ElementType.TYPE;

--- a/src/main/java/io/xlate/jsonapi/rvp/internal/validation/boundary/ValidJsonApiRequest.java
+++ b/src/main/java/io/xlate/jsonapi/rvp/internal/validation/boundary/ValidJsonApiRequest.java
@@ -1,19 +1,3 @@
-/*******************************************************************************
- * Copyright (C) 2018 xlate.io LLC, http://www.xlate.io
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
 package io.xlate.jsonapi.rvp.internal.validation.boundary;
 
 import static java.lang.annotation.ElementType.TYPE;


### PR DESCRIPTION
The license changed from AGPL to Apache 2 (see a8d091e324aa459aa8e50366a212cbe8cef1d814)

fixes #170